### PR TITLE
Wait for forms to be visible

### DIFF
--- a/test/create-protocol.test.js
+++ b/test/create-protocol.test.js
@@ -63,6 +63,7 @@ const createsANewForm = async () => {
   await architect.client.waitForVisible('=MANAGE FORMS');
   await architect.client.click('=MANAGE FORMS');
 
+  await architect.client.waitForVisible(formSelector);
   const builtInForms = await architect.client.elements(formSelector);
   expect(builtInForms.value).toHaveLength(1);
 


### PR DESCRIPTION
In some branches, rendering appears to be delayed to require this.